### PR TITLE
vmtests: update blacklists and image index

### DIFF
--- a/travis-ci/vmtest/configs/INDEX
+++ b/travis-ci/vmtest/configs/INDEX
@@ -1,5 +1,5 @@
 INDEX	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/INDEX
-libbpf-vmtest-rootfs-2020.03.11.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.03.11.tar.zst
+libbpf-vmtest-rootfs-2020.09.27.tar.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/libbpf-vmtest-rootfs-2020.09.27.tar.zst
 vmlinux-4.9.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-4.9.0.zst
 vmlinux-5.5.0-rc6.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0-rc6.zst
 vmlinux-5.5.0.zst	https://libbpf-vmtest.s3-us-west-1.amazonaws.com/x86_64/vmlinux-5.5.0.zst

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-5.5.0
@@ -15,7 +15,9 @@ cg_storage_multi	# v5.9+ functionality
 cgroup_attach_multi	# BPF_F_REPLACE_PROG missing
 cgroup_link		# LINK_CREATE is missing
 cgroup_skb_sk_lookup	# bpf_sk_lookup_tcp() helper is missing
+cls_redirect		# bpf_csum_level() helper is missing
 connect_force_port	# cgroup/get{peer,sock}name{4,6} support is missing
+d_path			# v5.10+ feature
 enable_stats		# BPF_ENABLE_STATS support is missing
 fentry_fexit		# bpf_prog_test_tracing missing
 fentry_test		# bpf_prog_test_tracing missing
@@ -24,6 +26,7 @@ fexit_test		# bpf_prog_test_tracing missing
 flow_dissector		# bpf_link-based flow dissector is in 5.8+
 flow_dissector_reattach
 get_stack_raw_tp	# exercising BPF verifier bug causing infinite loop
+kfree_skb		# 32-bit pointer arith in test_pkt_access
 ksyms			# __start_BTF has different name
 link_pinning		# bpf_link is missing
 load_bytes_relative	# new functionality in 5.8
@@ -32,6 +35,8 @@ mmap			# 5.5 kernel is too permissive with re-mmaping
 modify_return		# fmod_ret support is missing
 ns_current_pid_tgid	# bpf_get_ns_current_pid_tgid() helper is missing
 perf_branches		# bpf_read_branch_records() helper is missing
+pkt_access		# 32-bit pointer arith in test_pkt_access
+prog_run_xattr		# 32-bit pointer arith in test_pkt_access
 ringbuf			# BPF_MAP_TYPE_RINGBUF is supported in 5.8+
 
 # bug in verifier w/ tracking references
@@ -39,6 +44,7 @@ ringbuf			# BPF_MAP_TYPE_RINGBUF is supported in 5.8+
 reference_tracking
 
 select_reuseport	# UDP support is missing
+send_signal		# bpf_send_signal_thread() helper is missing
 sk_assign		# bpf_sk_assign helper missing
 skb_helpers		# helpers added in 5.8+
 sockmap_basic		# uses new socket fields, 5.8+
@@ -46,7 +52,10 @@ sockmap_listen		# no listen socket supportin SOCKMAP
 sockopt_sk
 sk_lookup		# v5.9+
 skb_ctx			# ctx_{size, }_{in, out} in BPF_PROG_TEST_RUN is missing
+tcp_hdr_options		# v5.10+, new TCP header options feature in BPF
+test_bpffs		# v5.10+, new CONFIG_BPF_PRELOAD=y and CONFIG_BPF_PRELOAD_UMG=y|m
 test_global_funcs	# kernel doesn't support BTF linkage=global on FUNCs
+test_local_storage	# v5.10+ feature
 test_lsm		# no BPF_LSM support
 test_overhead		# no fmod_ret support
 udp_limit		# no cgroup/sock_release BPF program type (5.9+)
@@ -58,8 +67,3 @@ xdp_bpf2bpf		# freplace is missing
 xdp_cpumap_attach	# v5.9+
 xdp_devmap_attach	# new feature in 5.8
 xdp_link		# v5.9+
-
-
-# TEMPORARILY DISABLED
-send_signal		# flaky
-cls_redirect		# latest Clang breaks BPF verification

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,7 +1,0 @@
-# TEMPORARILY DISABLED
-send_signal		# flaky
-test_lsm		# semi-working
-sk_assign		# needs better setup in Travis CI
-sk_lookup
-core_reloc		# temporary test breakage
-bpf_verif_scale		# clang regression


### PR DESCRIPTION
Update latest Linux image. Enable a bunch of previously disabled tests.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>